### PR TITLE
Add missing funder entries to Authors@R in DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,14 +2,16 @@ Package: HMP16SData
 Type: Package
 Title: 16S rRNA Sequencing Data from the Human Microbiome Project
 Version: 1.31.0
-Authors@R:
-    c(person(given = "Lucas", family = "schiffer", role = c("aut", "cre"),
-             email = "schiffer.lucas@gmail.com",
-             comment = c(ORCID = "0000-0003-3628-0326")),
-      person(given = "Rimsha", family = "Azhar", role = "aut"),
-      person(given = "Marcel", family = "Ramos", role = "ctb"),
-      person(given = "Ludwig", family = "Geistlinger", role = "ctb"),
-      person(given = "Levi", family = "Waldron", role = "aut"))
+Authors@R:c(
+    person("Lucas", "schiffer", , "schiffer.lucas@gmail.com", role = c("aut", "cre"),
+           comment = c(ORCID = "0000-0003-3628-0326")),
+    person("Rimsha", "Azhar", role = "aut"),
+    person("Marcel", "Ramos", role = "ctb"),
+    person("Ludwig", "Geistlinger", role = "ctb"),
+    person("Levi", "Waldron", role = "aut"),
+    person("NCI", role = "fnd",
+           comment = c(GrantNo. = "R01CA230551"))
+  )
 Description:
     HMP16SData is a Bioconductor ExperimentData package of the Human Microbiome
     Project (HMP) 16S rRNA sequencing data for variable regions 1–3 and 3–5. Raw


### PR DESCRIPTION
This automated PR adds missing \`fnd\` (funder) entries to the \`Authors@R\` field in \`DESCRIPTION\` based on the following grant topics set on this repository:

- R01CA230551

Opened by the [repo-audits](https://github.com/waldronlab/repo-audits) workflow (run [#23616342483](https://github.com/waldronlab/repo-audits/actions/runs/23616342483)).