### PR TITLE
Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,85 @@
+# --------------------------------------------
+# CITATION file created with {cffr} R package
+# See also: https://docs.ropensci.org/cffr/
+# --------------------------------------------
+ 
+cff-version: 1.2.0
+message: 'To cite package "HMP16SData" in publications use:'
+type: software
+license: Artistic-2.0
+title: 'HMP16SData: 16S rRNA Sequencing Data from the Human Microbiome Project'
+version: 1.33.1
+doi: 10.1093/aje/kwz006
+abstract: HMP16SData is a Bioconductor ExperimentData package of the Human Microbiome
+  Project (HMP) 16S rRNA sequencing data for variable regions 1–3 and 3–5. Raw data
+  files are provided in the package as downloaded from the HMP Data Analysis and Coordination
+  Center. Processed data is provided as SummarizedExperiment class objects via ExperimentHub.
+authors:
+- family-names: schiffer
+  given-names: Lucas
+  email: schiffer.lucas@gmail.com
+  orcid: https://orcid.org/0000-0003-3628-0326
+- family-names: Azhar
+  given-names: Rimsha
+- family-names: Waldron
+  given-names: Levi
+preferred-citation:
+  type: article
+  title: 'HMP16SData: Efficient Access to the Human Microbiome Project through Bioconductor'
+  authors:
+  - family-names: Schiffer
+    given-names: Lucas
+    email: schiffer.lucas@gmail.com
+    orcid: https://orcid.org/0000-0003-3628-0326
+  - family-names: Azhar
+    given-names: Rimsha
+  - family-names: Shepherd
+    given-names: Lori
+  - family-names: Ramos
+    given-names: Marcel
+  - family-names: Geistlinger
+    given-names: Ludwig
+  - family-names: Huttenhower
+    given-names: Curtis
+  - family-names: Dowd
+    given-names: Jennifer B
+  - family-names: Segata
+    given-names: Nicola
+  - family-names: Waldron
+    given-names: Levi
+  year: '2019'
+  doi: 10.1093/aje/kwz006
+  publisher:
+    name: Oxford University Press
+  journal: American Journal of Epidemiology
+repository: https://bioconductor.org/
+repository-code: https://github.com/waldronlab/HMP16SData
+url: https://github.com/waldronlab/HMP16SData
+date-released: '2026-05-14'
+contact:
+- family-names: schiffer
+  given-names: Lucas
+  email: schiffer.lucas@gmail.com
+  orcid: https://orcid.org/0000-0003-3628-0326
+keywords:
+- bioconductor
+- bioconductor-package
+- experimenthub
+- hmp
+- r01ca230551
+references:
+- type: manual
+  title: 'HMP16SData: 16S rRNA Sequencing Data from the Human Microbiome Project'
+  authors:
+  - family-names: schiffer
+    given-names: Lucas
+    email: schiffer.lucas@gmail.com
+    orcid: https://orcid.org/0000-0003-3628-0326
+  - family-names: Azhar
+    given-names: Rimsha
+  - family-names: Waldron
+    given-names: Levi
+  year: '2026'
+  notes: R package version 1.33.1
+  url: https://github.com/waldronlab/HMP16SData
+


### PR DESCRIPTION
This automated PR adds or updates `CITATION.cff` using the
[cffr](https://docs.ropensci.org/cffr/) R package (`cffr::cff_write()`).
Citation metadata is derived from the package `DESCRIPTION`, and the
auto-citation is also included as a `references` entry.

## Changes
- **Added / updated** `CITATION.cff` – generated by `cffr::cff_write()` with
  the auto-citation included under `references`

## How citations are handled
- If `inst/CITATION` exists in the repository it is automatically used by
  `cff_write()` as the `preferred-citation` in `CITATION.cff`.
- Otherwise, citation metadata is derived solely from `DESCRIPTION`.
- The auto-citation (equivalent to `citation(".", auto = TRUE)`) is always
  included under the `references` key so that both the preferred and the
  software citation are present.

## Why
A `CITATION.cff` file makes it easy for users and tools (GitHub, Zenodo,
Zotero, etc.) to cite your package correctly.

## Customisation
You can further customise the generated file by editing `CITATION.cff`
directly after this PR is merged. See the
[cffr vignette](https://docs.ropensci.org/cffr/articles/cffr.html) for
details.

Opened by the [repo-audits](https://github.com/waldronlab/repo-audits) workflow (run [#25884326248](https://github.com/waldronlab/repo-audits/actions/runs/25884326248)).
